### PR TITLE
Start using exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ class ComplexCoder(bream.Coder[complex]):
     def version(self) -> int:
         return 1
 
-    def encode(
-        self, value: complex, fmt: bream.SerialisationFormat
-    ) -> bream.EncodeError | bream.JsonType:
+    def encode(self, value: complex, fmt: bream.SerialisationFormat) -> bream.JsonType:
         del fmt
         return {"real": value.real, "imag": value.imag}
 
@@ -84,16 +82,16 @@ class ComplexCoder(bream.Coder[complex]):
         fmt: bream.SerialisationFormat,
         coder_version: int,
         bream_spec: int,
-    ) -> bream.DecodeError | complex:
+    ) -> complex:
         del bream_spec, fmt
         if coder_version != 1:
-            return bream.core.UnsupportedCoderVersion(self, coder_version)
+            raise bream.core.UnsupportedCoderVersionError(self, coder_version)
         if not isinstance(data, dict) or data.keys() != {"real", "imag"}:
-            return bream.core.InvalidPayloadData(self, data, "Invalid keys")
+            raise bream.core.InvalidPayloadDataError(self, data, "Invalid keys")
         if not isinstance(data["real"], float):
-            return bream.core.InvalidPayloadData(self, data, "Invalid 'real'")
+            raise bream.core.InvalidPayloadDataError(self, data, "Invalid 'real'")
         if not isinstance(data["imag"], float):
-            return bream.core.InvalidPayloadData(self, data, "Invalid 'imag'")
+            raise bream.core.InvalidPayloadDataError(self, data, "Invalid 'imag'")
         return complex(data["real"], data["imag"])
 ````
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,9 +23,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv]
-dev-dependencies = ["ruff ==0.9.9", "pyright ==1.1.392.post0", "pytest >=7"]
+dev-dependencies = ["ruff ==0.9.9", "pyright ==1.1.396", "pytest >=7"]
 python-preference = "only-managed"
-required-version = ">=0.5.24"
+required-version = ">=0.6.4"
 
 [tool.pyright]
 typeCheckingMode = "strict"

--- a/src/bream/__init__.py
+++ b/src/bream/__init__.py
@@ -4,9 +4,7 @@ from bream import coders, core
 from bream.core import (
     Codec,
     Coder,
-    DecodeError,
     Document,
-    EncodeError,
     JsonType,
     SerialisationFormat,
     TypeLabel,
@@ -20,9 +18,7 @@ from bream.core import (
 __all__ = [
     "Codec",
     "Coder",
-    "DecodeError",
     "Document",
-    "EncodeError",
     "JsonType",
     "SerialisationFormat",
     "TypeLabel",

--- a/src/bream/coders.py
+++ b/src/bream/coders.py
@@ -34,18 +34,24 @@ class DictCoder(Coder[dict[object, object]]):
         bream_spec: int,
     ) -> dict[object, object]:
         if coder_version != 1:
-            raise UnsupportedCoderVersionError(self, coder_version)
+            raise UnsupportedCoderVersionError(
+                coder=self, version_provided=coder_version
+            )
         if type(data) is not list:
             msg = f"Invalid payload data: {self}, {data}"
             raise ValueError(msg)
         result: dict[object, object] = {}
         for encoded_item in data:
             if not (isinstance(encoded_item, list) and len(encoded_item) == 2):
-                raise InvalidPayloadDataError(self, data, f"bad item: {encoded_item}")
+                raise InvalidPayloadDataError(
+                    coder=self, data=data, msg=f"bad item: {encoded_item}"
+                )
             encoded_k, encoded_v = encoded_item
             k = decode(encoded_k, fmt, bream_spec)
             if k in result:
-                raise InvalidPayloadDataError(self, data, f"duplicate key: {k}")
+                raise InvalidPayloadDataError(
+                    coder=self, data=data, msg=f"duplicate key: {k}"
+                )
             result[k] = decode(encoded_v, fmt, bream_spec)
 
         return result

--- a/src/bream/core.py
+++ b/src/bream/core.py
@@ -91,6 +91,21 @@ def _is_native_type(spec: TypeSpec) -> bool:
     return spec.module == "builtins" and spec.name in _NATIVE_TYPE_NAMES
 
 
+@dataclasses.dataclass(frozen=True, slots=True)
+class UnsupportedCoderVersionError(Exception):
+    """The version requested for deserialisation is not supported."""
+
+    coder: Coder[Any]
+    version_provided: int
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class InvalidPayloadDataError(Exception):
+    coder: Coder[Any]
+    data: JsonType
+    msg: str | None
+
+
 class Coder[T](abc.ABC):
     """Encapsulate encoding & decoding for a type or types."""
 
@@ -133,6 +148,10 @@ class Coder[T](abc.ABC):
 
         Note that `data` may contain other encoded types. Implementers should use `fmt`
         and `bream_spec` with `bream.decode` to decode any child entities.
+
+        Raises:
+            UnsupportedCoderVersionError: if `coder_version` is not supported.
+            InvalidPayloadDataError: if `data` is malformed.
         """
 
 

--- a/src/bream/core.py
+++ b/src/bream/core.py
@@ -91,16 +91,16 @@ def _is_native_type(spec: TypeSpec) -> bool:
     return spec.module == "builtins" and spec.name in _NATIVE_TYPE_NAMES
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
-class UnsupportedCoderVersionError(Exception):
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class UnsupportedCoderVersionError(ValueError):
     """The version requested for deserialisation is not supported."""
 
     coder: Coder[Any]
     version_provided: int
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
-class InvalidPayloadDataError(Exception):
+@dataclasses.dataclass(frozen=True, slots=True, kw_only=True)
+class InvalidPayloadDataError(ValueError):
     coder: Coder[Any]
     data: JsonType
     msg: str | None

--- a/src/bream/core.py
+++ b/src/bream/core.py
@@ -91,70 +91,6 @@ def _is_native_type(spec: TypeSpec) -> bool:
     return spec.module == "builtins" and spec.name in _NATIVE_TYPE_NAMES
 
 
-@dataclasses.dataclass(frozen=True, slots=True)
-class NoEncoderAvailable:
-    value: object
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class UnencodableDictKey:
-    value: object
-
-
-EncodeError = NoEncoderAvailable | UnencodableDictKey
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class UnsupportedBreamSpec:
-    """The bream spec specified for deserialisation is unsupported."""
-
-    bream_spec: int
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class NoDecoderAvailable:
-    """No decoder is available for the given type_label."""
-
-    type_label: TypeLabel
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class UnsupportedCoderVersion:
-    """The version requested for deserialisation is not supported."""
-
-    coder: Coder[Any]
-    version_provided: int
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class InvalidCoderEncoded:
-    """Got an invalid structure that is similar to but not a `bream.CoderEncoded`."""
-
-    obj: dict[str, JsonType]
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class InvalidPayloadData:
-    coder: Coder[Any]
-    data: JsonType
-    msg: str | None = None
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
-class InvalidJson:
-    data: object
-
-
-DecodeError = (
-    UnsupportedBreamSpec
-    | NoDecoderAvailable
-    | UnsupportedCoderVersion
-    | InvalidCoderEncoded
-    | InvalidPayloadData
-    | InvalidJson
-)
-
-
 class Coder[T](abc.ABC):
     """Encapsulate encoding & decoding for a type or types."""
 
@@ -178,13 +114,11 @@ class Coder[T](abc.ABC):
 
     # FIXME: open issue about avoiding cycles.
     @abc.abstractmethod
-    def encode(self, value: T, fmt: SerialisationFormat) -> EncodeError | JsonType:
+    def encode(self, value: T, fmt: SerialisationFormat) -> JsonType:
         """Encode `value` using this coder's current version.
 
         Note that this must encode recursively. Implementers should use `fmt` with
         `bream.encode` to encode any child entities.
-
-        Will return an `EncodeError` if encoding isn't possible.
         """
 
     @abc.abstractmethod
@@ -194,13 +128,11 @@ class Coder[T](abc.ABC):
         fmt: SerialisationFormat,
         coder_version: int,
         bream_spec: int,
-    ) -> DecodeError | T:
+    ) -> T:
         """Decode `data`, assuming it was encoded with `coder_version` of this coder.
 
         Note that `data` may contain other encoded types. Implementers should use `fmt`
         and `bream_spec` with `bream.decode` to decode any child entities.
-
-        Will return a `DecodeError` if decoding isn't possible.
         """
 
 
@@ -267,16 +199,13 @@ class SerialisationFormat:
         return self._label_to_codec.get(type_label)
 
 
-def encode_to_document(obj: object, fmt: SerialisationFormat) -> EncodeError | Document:
+def encode_to_document(obj: object, fmt: SerialisationFormat) -> Document:
     """Encode `obj`, and place inside an bream document."""
     payload = encode(obj, fmt)
-    if isinstance(payload, EncodeError):
-        return payload
-
     return {Keys.bream_spec.value: BREAM_SPEC, Keys.payload.value: payload}
 
 
-def encode(obj: object, fmt: SerialisationFormat) -> EncodeError | JsonType:
+def encode(obj: object, fmt: SerialisationFormat) -> JsonType:
     if _is_native_element(obj):
         return obj
 
@@ -290,26 +219,17 @@ def encode(obj: object, fmt: SerialisationFormat) -> EncodeError | JsonType:
 
 
 # TODO: should these be Coders for builtins?
-def _encode_list(
-    obj: list[Any], fmt: SerialisationFormat
-) -> EncodeError | list[JsonType]:
-    result: list[JsonType] = []
-    for x in obj:
-        x_encoded = encode(x, fmt)
-        if isinstance(x_encoded, EncodeError):
-            return x_encoded
-        result.append(x_encoded)
-    return result
+def _encode_list(obj: list[Any], fmt: SerialisationFormat) -> list[JsonType]:
+    return [encode(x, fmt) for x in obj]
 
 
-def _encode_custom(obj: object, fmt: SerialisationFormat) -> EncodeError | CoderEncoded:
+def _encode_custom(obj: object, fmt: SerialisationFormat) -> CoderEncoded:
     codec = fmt.find_codec_for_value(obj)
     if codec is None:
-        return NoEncoderAvailable(obj)
+        msg = f"No encoder for {obj}"
+        raise ValueError(msg)
 
     payload = codec.coder.encode(obj, fmt)
-    if isinstance(payload, EncodeError):
-        return payload
     return {
         Keys.type_label.value: codec.type_label,
         Keys.version.value: codec.coder.version,
@@ -317,19 +237,16 @@ def _encode_custom(obj: object, fmt: SerialisationFormat) -> EncodeError | Coder
     }
 
 
-def decode_document(
-    document: Document, fmt: SerialisationFormat
-) -> DecodeError | object:
+def decode_document(document: Document, fmt: SerialisationFormat) -> object:
     """Decode an bream document."""
     return decode(obj=document["_payload"], fmt=fmt, bream_spec=document["_bream_spec"])
 
 
-def decode(
-    obj: JsonType, fmt: SerialisationFormat, bream_spec: int
-) -> DecodeError | object:
+def decode(obj: JsonType, fmt: SerialisationFormat, bream_spec: int) -> object:
     # FIXME: version 0 should get a special error once we go stable.
     if bream_spec != 0:
-        return UnsupportedBreamSpec(bream_spec=bream_spec)
+        msg = f"Unsupported bream_spec: {bream_spec}"
+        raise ValueError(msg)
 
     if _is_native_element(obj):
         return obj
@@ -339,34 +256,28 @@ def decode(
 
     if type(obj) is dict:
         if not _is_coder_encoded(obj):
-            return InvalidCoderEncoded(obj)
+            msg = f"Invalid coder-encoded: {obj}"
+            raise ValueError(msg)
         return _decode_custom(obj, fmt, bream_spec)
 
-    return InvalidJson(obj)
+    msg = f"Invalid json: {obj}"
+    raise ValueError(msg)
 
 
 def _decode_list(
     obj: list[JsonType], fmt: SerialisationFormat, bream_spec: int
-) -> DecodeError | list[object]:
-    res: list[object] = []
-    for x in obj:
-        tmp = decode(x, fmt, bream_spec)
-        # FIXME: that we're not getting a linter error since the success path might just
-        # be an 'object'. We should probably use some kind of 'Result' type if avoiding
-        # exceptions.
-        if isinstance(tmp, DecodeError):
-            return tmp
-        res.append(x)
-    return res
+) -> list[object]:
+    return [decode(x, fmt, bream_spec) for x in obj]
 
 
 def _decode_custom(
     obj: CoderEncoded, fmt: SerialisationFormat, bream_spec: int
-) -> DecodeError | object:
+) -> object:
     type_label = obj[Keys.type_label.value]
     codec = fmt.find_codec_for_type_label(type_label)
     if codec is None:
-        return NoDecoderAvailable(type_label)
+        msg = f"No codec available for {type_label}"
+        raise ValueError(msg)
 
     version = obj[Keys.version.value]
     payload = obj[Keys.payload.value]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Any
 
+import pytest
+
 import bream
-from bream.core import EncodeError
 
 
 def test_scalar_encode() -> None:
@@ -24,9 +25,12 @@ def test_list_encode() -> None:
 
 def test_unsupported_encode() -> None:
     fmt = bream.SerialisationFormat(codecs=())
-    assert bream.encode(1j, fmt) == bream.core.NoEncoderAvailable(value=1j)
-    assert bream.encode((42,), fmt) == bream.core.NoEncoderAvailable(value=(42,))
-    assert bream.encode({3}, fmt) == bream.core.NoEncoderAvailable(value={3})
+    with pytest.raises(ValueError, match="No encoder for 1j"):
+        bream.encode(1j, fmt)
+    with pytest.raises(ValueError, match="No encoder for (42,)"):
+        bream.encode((42,), fmt)
+    with pytest.raises(ValueError, match="No encoder for {3}"):
+        bream.encode({3}, fmt)
 
 
 def test_scalar_decode() -> None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
@@ -27,9 +28,9 @@ def test_unsupported_encode() -> None:
     fmt = bream.SerialisationFormat(codecs=())
     with pytest.raises(ValueError, match="No encoder for 1j"):
         bream.encode(1j, fmt)
-    with pytest.raises(ValueError, match="No encoder for (42,)"):
+    with pytest.raises(ValueError, match=re.escape("No encoder for (42,)")):
         bream.encode((42,), fmt)
-    with pytest.raises(ValueError, match="No encoder for {3}"):
+    with pytest.raises(ValueError, match=re.escape("No encoder for {3}")):
         bream.encode({3}, fmt)
 
 
@@ -56,7 +57,6 @@ def test_nested_structure_round_trip() -> None:
     x = [None, 2, 4.2, "moo"]
     y = ["a", None, x]
     y_encoded = bream.encode(y, fmt)
-    assert not isinstance(y_encoded, EncodeError)
     assert y_encoded == y
     assert y_encoded is not y
     y_decoded = bream.decode(y_encoded, fmt, bream.core.BREAM_SPEC)
@@ -68,7 +68,6 @@ def test_simple_document_round_trip() -> None:
     fmt = bream.SerialisationFormat(codecs=())
     for x in (None, 2, 4.2, "moo", [1, None, 3], ["a", [3, 4], "b", ["c", 4.2]]):
         document = bream.encode_to_document(x, fmt)
-        assert not isinstance(document, bream.EncodeError)
         assert document == {"_bream_spec": bream.core.BREAM_SPEC, "_payload": x}
         new_x = bream.decode_document(document, fmt)
         assert new_x == x
@@ -88,8 +87,8 @@ def test_float_subtype_not_accepted() -> None:
     fmt = bream.SerialisationFormat(codecs=())
     x = _MyFloat(1)
     assert isinstance(x, float)
-    x_encoded = bream.encode(x, fmt)
-    assert x_encoded == bream.core.NoEncoderAvailable(x)
+    with pytest.raises(ValueError, match=re.escape(f"No encoder for {x}")):
+        bream.encode(x, fmt)
 
 
 class _MyList(list[Any]):
@@ -100,5 +99,5 @@ def test_list_subtype_not_accepted() -> None:
     fmt = bream.SerialisationFormat(codecs=())
     x = _MyList([1, 2, 3])
     assert isinstance(x, list)
-    x_encoded = bream.encode(x, fmt)
-    assert x_encoded == bream.core.NoEncoderAvailable(x)
+    with pytest.raises(ValueError, match=re.escape(f"No encoder for {x}")):
+        bream.encode(x, fmt)

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -79,9 +79,10 @@ class CowCoder(bream.Coder[Cow]):
         return 1
 
     def encode(self, value: Cow, fmt: bream.SerialisationFormat) -> bream.JsonType:
-        moo1 = bream.encode(value.moo1, fmt)
-        moo2 = bream.encode(value.moo2, fmt)
-        return {"moo1": moo1, "moo2": moo2}
+        return {
+            "moo1": bream.encode(value.moo1, fmt),
+            "moo2": bream.encode(value.moo2, fmt),
+        }
 
     def decode(
         self,

--- a/tests/test_custom.py
+++ b/tests/test_custom.py
@@ -30,13 +30,21 @@ class ComplexCoder(bream.Coder[complex]):
     ) -> complex:
         del bream_spec, fmt
         if coder_version != 1:
-            raise bream.core.UnsupportedCoderVersionError(self, coder_version)
+            raise bream.core.UnsupportedCoderVersionError(
+                coder=self, version_provided=coder_version
+            )
         if not isinstance(data, dict) or data.keys() != {"real", "imag"}:
-            raise bream.core.InvalidPayloadDataError(self, data, "Invalid keys")
+            raise bream.core.InvalidPayloadDataError(
+                coder=self, data=data, msg="Invalid keys"
+            )
         if not isinstance(data["real"], float):
-            raise bream.core.InvalidPayloadDataError(self, data, "Invalid 'real'")
+            raise bream.core.InvalidPayloadDataError(
+                coder=self, data=data, msg="Invalid 'real'"
+            )
         if not isinstance(data["imag"], float):
-            raise bream.core.InvalidPayloadDataError(self, data, "Invalid 'imag'")
+            raise bream.core.InvalidPayloadDataError(
+                coder=self, data=data, msg="Invalid 'imag'"
+            )
         return complex(data["real"], data["imag"])
 
 
@@ -92,7 +100,9 @@ class CowCoder(bream.Coder[Cow]):
         bream_spec: int,
     ) -> Cow:
         if coder_version != 1:
-            raise bream.core.UnsupportedCoderVersionError(self, coder_version)
+            raise bream.core.UnsupportedCoderVersionError(
+                coder=self, version_provided=coder_version
+            )
 
         match data:
             case {"moo1": moo1, "moo2": moo2}:
@@ -103,9 +113,9 @@ class CowCoder(bream.Coder[Cow]):
                     case (Moo(), Moo()):
                         return Cow(moo1=moo1, moo2=moo2)
                     case _:
-                        raise InvalidPayloadDataError(self, data, None)
+                        raise InvalidPayloadDataError(coder=self, data=data, msg=None)
             case _:
-                raise InvalidPayloadDataError(self, data, "Invalid keys")
+                raise InvalidPayloadDataError(coder=self, data=data, msg="Invalid keys")
 
 
 def test_custom_complex() -> None:


### PR DESCRIPTION
Considering #5 .

Python isn't really designed for ergonomic handling of error-types, especially when they start to get nested (contrasting to Rust, where you have the `?` token to replace the 'if this value is an error then return it from the function now, otherwise unpack the result' logic). As much as I'd rather be working with e.g. Rust, possibly just using exceptions here is going to add less friction for more involved use of the library.

In particular, @cgravill's new nested encoder has somewhat less error-case handling, and this is for a relatively simple case.

The one thing this _won't_ help with is "accumulating all the errors and reporting", but I'd tend to prefer to defer that problem to the future, if we decide to care about it.